### PR TITLE
feat: configure access code and backend from env

### DIFF
--- a/TECH_README.md
+++ b/TECH_README.md
@@ -1,0 +1,8 @@
+# Technical Notes
+
+## Environment Variables
+
+- `BOILRPLATE_ACCESS_CODE`: Access code required to unlock AI-powered project generation. The CLI reads this value from the environment.
+- `BACKEND_URL`: Base URL used for documentation and waitlist links. Configure this to point at the backend service.
+
+The CLI now relies on these variables instead of hard-coded strings in `bin/index.js`.

--- a/bin/index.js
+++ b/bin/index.js
@@ -16,7 +16,7 @@ import {
   createSpinner,
   displayError
 } from '../lib/display.js';
-import { VALID_ACCESS_CODE, DEFAULT_APP_NAME, APP_URL } from '../lib/config.js';
+import { DEFAULT_APP_NAME, BACKEND_URL } from '../lib/config.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -28,6 +28,7 @@ async function runCLI() {
   const argv = minimist(process.argv.slice(2));
   const input = argv._.join(' ').trim();
   const accessCode = argv.access;
+  const validAccessCode = process.env.BOILRPLATE_ACCESS_CODE;
 
   const loadingSpinner = createSpinner('Loading templates...');
   loadingSpinner.start();
@@ -36,15 +37,15 @@ async function runCLI() {
   loadingSpinner.succeed('Templates loaded');
 
   if (input && accessCode) {
-    if (accessCode === VALID_ACCESS_CODE) {
+    if (accessCode === validAccessCode) {
       console.log(chalk.green('✅ Access code accepted! Unlocking AI-powered setup...\n'));
       return runAIMode(input);
     } else {
       console.log(chalk.yellow(randomWaitlistMessage()));
       console.log(chalk.cyan(`
 📚 Check the docs for predefined templates:
-🔗 ${APP_URL}
-📬 Or join the waitlist:  ${APP_URL}
+🔗 ${BACKEND_URL}
+📬 Or join the waitlist:  ${BACKEND_URL}
 `));
       return;
     }
@@ -74,7 +75,7 @@ async function runCLI() {
 🚧 AI-powered custom scaffolding is still under development!
 
   Join the waitlist and get early access:
-  ${APP_URL}
+  ${BACKEND_URL}
 
 Meanwhile, explore predefined templates today!
 `));

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,5 @@
-export const VALID_ACCESS_CODE = process.env.BOILR_ACCESS_CODE || 'BLRP-CLI-AP';
 export const DEFAULT_APP_NAME = process.env.DEFAULT_APP_NAME || 'boilr-app';
-export const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'https://boilrplate-app-ldmom.ondigitalocean.app';
+export const BACKEND_URL = process.env.BACKEND_URL || 'https://boilrplate-app-ldmom.ondigitalocean.app';
 export const APP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://www.heyboilrplate.com';
 export const SUPPORT_EMAIL = process.env.NEXT_PUBLIC_SUPPORT_EMAIL || 'purohitaman@icloud.com';
 export const CLI_NAME = process.env.NEXT_PUBLIC_APP_NAME || 'boilrplate';


### PR DESCRIPTION
## Summary
- read access code from `BOILRPLATE_ACCESS_CODE`
- link CLI messages to `BACKEND_URL`
- document environment variables for configuration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a47826e29c8333bc2d5f3c0ce9af96